### PR TITLE
Kihotry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .idea/
+__pycache__/

--- a/main.py
+++ b/main.py
@@ -1,6 +1,5 @@
 __author__ = "Shivam Shekhar"
 made_by = "OldKokiri-6"
-abcde = "test1"
 
 import os
 import sys

--- a/main.py
+++ b/main.py
@@ -12,7 +12,7 @@ pygame.init()
 
 scr_size = (width,height) = (600,200)      #초기 화면사이즈
 FPS = 60                                   #캐릭터와 장애물이 움직이는 속도(단계별로 조정할 부분)
-gravity = 0.65                              #캐릭터 점프높이의 정도(gravity가 커질수록 점프하는 폭이 작아짐)
+gravity = 0.65                             #캐릭터 점프높이의 정도(gravity가 커질수록 점프하는 폭이 작아짐)
 
 black = (0,0,0)
 white = (255,255,255)

--- a/main.py
+++ b/main.py
@@ -1,5 +1,6 @@
 __author__ = "Shivam Shekhar"
 made_by = "OldKokiri-6"
+abcde = "test1"
 
 import os
 import sys

--- a/main.py
+++ b/main.py
@@ -371,6 +371,7 @@ def pausing():
 
                 if event.type == pygame.KEYDOWN:
                     if event.key == pygame.K_ESCAPE:
+                        pygame.mixer.music.unpause() # pausing상태에서 다시 esc누르면 배경음악 일시정지 해제
                         return False
 
                 if event.type == pygame.MOUSEBUTTONDOWN:

--- a/main.py
+++ b/main.py
@@ -13,7 +13,7 @@ db = InterfDB("score.db")
 
 
 def introscreen():
-    background_music.stop()
+    pygame.mixer.music.stop()
     temp_dino = Dino(44, 47)
     temp_dino.isBlinking = True
     gameStart = False
@@ -74,7 +74,7 @@ def introscreen():
 
 
 def gameplay():
-    background_music.play(loops=True)  # 배경음악 실행
+    pygame.mixer.music.play(-1) # 배경음악 실행
     global high_score
     gamespeed = 4
     startMenu = False
@@ -233,7 +233,7 @@ def gameplay():
 
                 if playerDino.isDead:
                     gameOver = True
-                    background_music.stop()  # 죽으면 배경음악 멈춤
+                    pygame.mixer.music.stop() #죽으면 배경음악 멈춤
                     if playerDino.score > high_score:
                         high_score = playerDino.score
                     db.query_db(f"insert into user(username, score) values ('nnn', '{playerDino.score}');")
@@ -355,6 +355,7 @@ def board():
 
 def pausing():
     gameQuit = False
+    pygame.mixer.music.pause() # 일시정지상태가 되면 배경음악도 일시정지
 
     retbutton_image, retbutton_rect = load_image('replay_button.png', 35, 31, -1)
     resume_image, resume_rect = load_image('replay_button.png', 35, 31, -1)
@@ -378,6 +379,7 @@ def pausing():
                         if retbutton_rect.collidepoint(x, y):
                             introscreen()
                         if resume_rect.collidepoint(x, y):
+                            pygame.mixer.music.unpause() # pausing상태에서 오른쪽의 아이콘 클릭하면 배경음악 일시정지 해제
                             return False
 
                 if event.type == pygame.VIDEORESIZE:

--- a/setting.py
+++ b/setting.py
@@ -26,7 +26,8 @@ pygame.display.set_caption("T-Rex Rush by_OldKokiri")     #게임창의 캡션
 jump_sound = pygame.mixer.Sound('sprites/jump.wav')
 die_sound = pygame.mixer.Sound('sprites/die.wav')
 checkPoint_sound = pygame.mixer.Sound('sprites/checkPoint.wav')
-background_music = pygame.mixer.Sound('sprites/t-rex_bgm1.mp3') #배경음악 지정-363째줄 코드에서 시작, 505째줄 코드에서 멈춤
+#background_music = pygame.mixer.Sound('sprites/t-rex_bgm1.mp3') #일시정지 구현을 위해 기존함수 대신 아랫줄의 다른함수 사용
+pygame.mixer.music.load('sprites/t-rex_bgm1.mp3') #배경음악 지정
 
 
 def load_image(


### PR DESCRIPTION
- 배경음악 무한루프부분의 loop가 2번밖에 재생되지 않는 오류를 발견하여
    loop 대신 -1을 넣어서 무한반복되도록 구현했습니다.

- pygame.mixer.music.pause()와 unpause()를 이용해서 일시정지상태일때 배경음악도 같이 일시정지되고 일시정지 해제되도록 
   구현했습니다.

- 다만 이렇게 할때 setting.py파일에서 기존의 background_music변수에 음악을 지정해서 하는 
    background_music = pygame.mixer.sound 방식이 잘 안되어서, 
    pygame.mixer.music.load로 변경하였습니다.

- 새로 발견한 개선해야 할 사항으로는 일시정지 상태에서 창 리사이징을 하면 화면의 버튼이 클릭이 되지 않아서
   클릭이 되는 좌표를 조정해야 할 것 같습니다.